### PR TITLE
refactor: extract secure setup script

### DIFF
--- a/gpt-gui.sh
+++ b/gpt-gui.sh
@@ -160,32 +160,3 @@ while true; do
  
  unset OPENAI_API_KEY
  exit 0
- EOF1
- 
- # gpt-secure-setup.sh
- cat <<'EOF1' > "$BASE_DIR/gpt-secure-setup.sh"
-#!/bin/bash
-# Script para configurar chave da API OpenAI de forma segura.
-set -e
-SECRET_DIR="$HOME/.local/share/chatgpt-cli"
-CONFIG_DIR="$HOME/.config/chatgpt-cli"
-mkdir -p "$SECRET_DIR"
-mkdir -p "$CONFIG_DIR"
-
-echo "Configuração segura da chave API OpenAI."
-read -rp "Digite sua OpenAI API key: " api_key
-if [ -z "$api_key" ]; then
-    echo "Chave vazia. Abortando."
-    exit 1
-fi
-
-read -rsp "Crie uma senha mestra: " pass1; echo
-read -rsp "Confirme a senha mestra: " pass2; echo
-if [ "$pass1" != "$pass2" ]; then
-    echo "As senhas não coincidem."
-    exit 1
-fi
-
-echo -n "$api_key" | openssl enc -aes-256-cbc -pbkdf2 -iter 200000 -md sha256 -salt -out "$SECRET_DIR/secret.enc" -pass pass:"$pass1"
-chmod 600 "$SECRET_DIR/secret.enc"
- echo "Chave criptografada e salva em $SECRET_DIR/secret.enc"

--- a/gpt-secure-setup.sh
+++ b/gpt-secure-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Script para configurar chave da API OpenAI de forma segura.
+set -e
+SECRET_DIR="$HOME/.local/share/chatgpt-cli"
+CONFIG_DIR="$HOME/.config/chatgpt-cli"
+mkdir -p "$SECRET_DIR"
+mkdir -p "$CONFIG_DIR"
+
+echo "Configuração segura da chave API OpenAI."
+read -rp "Digite sua OpenAI API key: " api_key
+if [ -z "$api_key" ]; then
+    echo "Chave vazia. Abortando."
+    exit 1
+fi
+
+read -rsp "Crie uma senha mestra: " pass1; echo
+read -rsp "Confirme a senha mestra: " pass2; echo
+if [ "$pass1" != "$pass2" ]; then
+    echo "As senhas não coincidem."
+    exit 1
+fi
+
+echo -n "$api_key" | openssl enc -aes-256-cbc -pbkdf2 -iter 200000 -md sha256 -salt -out "$SECRET_DIR/secret.enc" -pass pass:"$pass1"
+chmod 600 "$SECRET_DIR/secret.enc"
+echo "Chave criptografada e salva em $SECRET_DIR/secret.enc"


### PR DESCRIPTION
## Summary
- move secure API key setup into standalone `gpt-secure-setup.sh`
- simplify GUI script and call the secure setup script directly

## Testing
- `bash -n gpt-gui.sh gpt-secure-setup.sh`
- `shellcheck gpt-gui.sh gpt-secure-setup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9343a63c8330bf418385f67f4030