### PR TITLE
Handle missing message in API responses

### DIFF
--- a/gpt_cli.py
+++ b/gpt_cli.py
@@ -228,7 +228,7 @@ def main():
                 if 'output' in data:
                     response_text = data['output']
                 elif 'choices' in data and len(data['choices']) > 0:
-                    response_text = data['choices'][0].get('message','').get('content','')
+                    response_text = data['choices'][0].get('message', {}).get('content', '')
                 else:
                     response_text = str(data)
             print(response_text)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+def test_response_without_message_key() -> None:
+    data: dict[str, list[dict[str, Any]]] = {"choices": [{}]}
+    response_text: str = data["choices"][0].get("message", {}).get("content", "")
+    assert response_text == ""


### PR DESCRIPTION
## Summary
- Avoid exception when API choice lacks `message` key
- Add unit test for message-less response

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc93457684833097a0be250b561053