### PR TITLE
Improve update check robustness

### DIFF
--- a/check-update.sh
+++ b/check-update.sh
@@ -11,20 +11,29 @@ NEW_URL=""
 HUMAN_MSG=""
 
 if [ -n "$GH_REPO" ]; then
-  resp=$(curl -s "https://api.github.com/repos/$GH_REPO/releases/latest")
-  tag=$(echo "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":\s*"v?([^\"]+)".*/\1/')
-  url=$(echo "$resp" | grep -o '"browser_download_url":[^,]*' | sed -E 's/.*"browser_download_url":\s*"([^\"]+)".*/\1/' | grep 'chatgpt-cli-secure' | head -n1)
-  if [ -n "$tag" ]; then
-    latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
-    if [ "$latest" != "$LOCAL_VERSION" ]; then
-      HAS_UPDATE=1
-      NEW_VERSION="$tag"
-      NEW_URL="$url"
+  if resp=$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" 2>/dev/null); then
+    if command -v jq >/dev/null 2>&1; then
+      tag=$(jq -r '.tag_name // empty' <<<"$resp")
+      url=$(jq -r '.assets[]?.browser_download_url // empty' <<<"$resp" | grep 'chatgpt-cli-secure' | head -n1)
+    else
+      echo "Aviso: jq não encontrado; a extração será menos robusta. Instale jq para melhor desempenho." >&2
+      tag=$(echo "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":\s*"v?([^\"]+)".*/\1/')
+      url=$(echo "$resp" | grep -o '"browser_download_url":[^,]*' | sed -E 's/.*"browser_download_url":\s*"([^\"]+)".*/\1/' | grep 'chatgpt-cli-secure' | head -n1)
     fi
+    if [ -n "$tag" ] && [ -n "$url" ]; then
+      latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
+      if [ "$latest" != "$LOCAL_VERSION" ]; then
+        HAS_UPDATE=1
+        NEW_VERSION="$tag"
+        NEW_URL="$url"
+      fi
+    fi
+    HUMAN_MSG="Verificação via GitHub."
+  else
+    HUMAN_MSG="Erro ao consultar GitHub."
   fi
-  HUMAN_MSG="Verificação via GitHub."
 elif [ -n "$UPDATE_URL" ]; then
-  tag=$(curl -s "$UPDATE_URL/version.txt" | tr -d ' \t\n\r')
+  tag=$(curl -fsSL "$UPDATE_URL/version.txt" 2>/dev/null | tr -d ' \t\n\r')
   url="$UPDATE_URL/chatgpt-cli-secure.tar.gz"
   if [ -n "$tag" ]; then
     latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
@@ -33,8 +42,10 @@ elif [ -n "$UPDATE_URL" ]; then
       NEW_VERSION="$tag"
       NEW_URL="$url"
     fi
+    HUMAN_MSG="Verificação via URL."
+  else
+    HUMAN_MSG="Erro ao obter versão em URL."
   fi
-  HUMAN_MSG="Verificação via URL."
 else
   HUMAN_MSG="Nenhuma origem de atualização configurada."
 fi


### PR DESCRIPTION
## Summary
- handle network failures with `curl -fsSL`
- parse GitHub releases using `jq` when available
- warn when `jq` missing and validate update fields

## Testing
- `shellcheck check-update.sh`
- `./check-update.sh --machine-read`


------
https://chatgpt.com/codex/tasks/task_e_68bc934bcf3883309e074be3e1b315af