### PR TITLE
refactor: secure config parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ UPDATE_URL=""   # Ex.: "https://meuservidor.com/updates"
 GH_REPO=""      # Ex.: "usuario/repositorio" para releases do GitHub
 ```
 
+- Cada linha deve seguir o formato `CHAVE=valor` e linhas iniciadas por `#` são ignoradas.
+- Para o script `check-update.sh`, somente `UPDATE_URL` e `GH_REPO` são interpretadas; variáveis não reconhecidas são ignoradas.
+- Entradas malformadas fazem o script abortar, evitando execução acidental de comandos.
+
 - **MODEL**: modelo padrão usado pela CLI/GUI (pode ser alterado no menu da GUI ou manualmente).
 - **TEMP**: temperatura padrão (0 a 1).
 - **UPDATE_URL**: URL onde deve existir um `version.txt` e um pacote `chatgpt-cli-secure.tar.gz`.

--- a/tests/test_check_update_config.py
+++ b/tests/test_check_update_config.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+from pathlib import Path
+
+def run_check(tmp_path: Path, config_text: str) -> subprocess.CompletedProcess[str]:
+    config_dir: Path = tmp_path / '.config/chatgpt-cli'
+    config_dir.mkdir(parents=True)
+    (config_dir / 'config').write_text(config_text)
+    env: dict[str, str] = {**os.environ, 'HOME': str(tmp_path)}
+    env.pop('GH_REPO', None)
+    env.pop('UPDATE_URL', None)
+    return subprocess.run(
+        ['bash', 'check-update.sh', '--machine-read'],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+def test_valid_config(tmp_path: Path) -> None:
+    result = run_check(tmp_path, '#comentario\nGH_REPO=\nUNSAFE=1\n')
+    assert result.returncode == 0
+    assert 'HAS_UPDATE=0' in result.stdout
+
+def test_malformed_line(tmp_path: Path) -> None:
+    result = run_check(tmp_path, 'BADLINE')
+    assert result.returncode != 0
+    assert 'Linha malformada' in result.stderr


### PR DESCRIPTION
## Summary
- replace unsafe sourcing in check-update.sh with validated, whitelisted parsing
- document config format and allowed variables
- add tests for config parsing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc9b6414188330817ec9f6c2ba2bd3