### PR TITLE
Ensure update script cleans temporary directory and add tests

### DIFF
--- a/tests/test_update_tmp.py
+++ b/tests/test_update_tmp.py
@@ -1,0 +1,41 @@
+import os
+import tarfile
+from pathlib import Path
+import subprocess
+
+def _create_package(tmp_dir: Path, script: str) -> Path:
+    pkg_dir = tmp_dir / "pkg"
+    pkg_dir.mkdir()
+    install_script = pkg_dir / "install.sh"
+    install_script.write_text(script)
+    install_script.chmod(0o755)
+    tar_path = tmp_dir / "pkg.tar"
+    with tarfile.open(tar_path, "w") as tar:
+        tar.add(pkg_dir, arcname="pkg")
+    return tar_path
+
+def _run_update(tar_path: Path, base_tmp: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["TMPDIR"] = str(base_tmp)
+    return subprocess.run([
+        "bash",
+        "update.sh",
+        "--from-file",
+        str(tar_path),
+    ], cwd=str(Path(__file__).resolve().parent.parent), capture_output=True, text=True, env=env)
+
+def test_tmp_removed_on_success(tmp_path: Path) -> None:
+    base_tmp = tmp_path / "tmp"
+    base_tmp.mkdir()
+    tar_path = _create_package(tmp_path, "#!/bin/bash\nexit 0\n")
+    result = _run_update(tar_path, base_tmp)
+    assert result.returncode == 0
+    assert list(base_tmp.iterdir()) == []
+
+def test_tmp_removed_on_failure(tmp_path: Path) -> None:
+    base_tmp = tmp_path / "tmp"
+    base_tmp.mkdir()
+    tar_path = _create_package(tmp_path, "#!/bin/bash\nexit 1\n")
+    result = _run_update(tar_path, base_tmp)
+    assert result.returncode != 0
+    assert list(base_tmp.iterdir()) == []

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,9 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
 usage() {
   echo "Uso: $0 --from-github | --from-url <URL> | --from-file <arquivo>"
   exit 1
@@ -16,7 +19,6 @@ if [ "$1" == "--from-github" ]; then
     echo "Nenhuma atualização disponível."
     exit 0
   fi
-  tmp=$(mktemp -d)
   file="$tmp/package.tar.gz"
   echo "Baixando pacote de atualização..."
   curl -L -o "$file" "$url"
@@ -31,7 +33,6 @@ if [ "$1" == "--from-github" ]; then
 elif [ "$1" == "--from-url" ]; then
   url="$2"
   [ -z "$url" ] && usage
-  tmp=$(mktemp -d)
   file="$tmp/package.tar.gz"
   echo "Baixando pacote..."
   curl -L -o "$file" "$url"
@@ -42,7 +43,6 @@ elif [ "$1" == "--from-url" ]; then
 elif [ "$1" == "--from-file" ]; then
   file="$2"
   [ -z "$file" ] && usage
-  tmp=$(mktemp -d)
   tar -xf "$file" -C "$tmp"
   dir=$(find "$tmp" -maxdepth 1 -mindepth 1 -type d | head -n1)
   bash "$dir/install.sh"


### PR DESCRIPTION
## Summary
- Clean up temporary directory in `update.sh` using `trap`
- Cover temp directory removal on success and failure

## Testing
- `bash -n update.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c65003c83309a439d2f8d5b44f3