### PR TITLE
Cache release headers before full update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - O histórico e as sessões são armazenados respeitando os padrões XDG (em `~/.local/state/chatgpt-cli/`).
 
 - **Sistema de atualização**:
-  - `check-update.sh` verifica se há nova versão em GitHub ou em URL configurada.
+  - `check-update.sh` verifica se há nova versão em GitHub ou em URL configurada, usando `curl -fI` para obter `ETag` ou `Last-Modified`. O token retornado é armazenado em `~/.local/state/chatgpt-cli/` e reutilizado em execuções futuras, baixando detalhes completos apenas quando houver mudança.
   - `update.sh` baixa e instala a atualização a partir de GitHub, URL ou arquivo local.
   - A GUI integra o fluxo de verificação/instalação de atualização.
 

--- a/check-update.sh
+++ b/check-update.sh
@@ -4,6 +4,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOCAL_VERSION=$(cat "$SCRIPT_DIR/version.txt")
 CONFIG="$HOME/.config/chatgpt-cli/config"
 ALLOWED_VARS="GH_REPO UPDATE_URL"
+STATE_DIR="$HOME/.local/state/chatgpt-cli"
+GH_CACHE="$STATE_DIR/github_release.cache"
+URL_CACHE="$STATE_DIR/url_release.cache"
+
+mkdir -p "$STATE_DIR"
+
 if [ -f "$CONFIG" ]; then
   # Loop simples; usar `grep` ou `awk` seria mais performático, mas a leitura linha a linha
   # facilita a validação e manutenção.
@@ -30,14 +36,32 @@ NEW_URL=""
 HUMAN_MSG=""
 
 if [ -n "$GH_REPO" ]; then
-  if resp=$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" 2>/dev/null); then
-    if command -v jq >/dev/null 2>&1; then
-      tag=$(jq -r '.tag_name // empty' <<<"$resp")
-      url=$(jq -r '.assets[]?.browser_download_url // empty' <<<"$resp" | grep 'chatgpt-cli-secure' | head -n1)
+  # `curl -fI` obtém apenas cabeçalhos, economizando dados.
+  headers=$(curl -fIsL "https://api.github.com/repos/$GH_REPO/releases/latest" 2>/dev/null)
+  if [ -n "$headers" ]; then
+    etag=$(grep -i '^ETag:' <<<"$headers" | tr -d '\r' | awk '{print $2}' | tr -d '"')
+    last_mod=$(grep -i '^Last-Modified:' <<<"$headers" | cut -d' ' -f2- | tr -d '\r')
+    token=${etag:-$last_mod}
+    cache_token=""
+    if [ -f "$GH_CACHE" ]; then
+      cache_token=$(grep '^ETAG=' "$GH_CACHE" | cut -d= -f2-)
+    fi
+    if [ "$token" != "$cache_token" ] || [ ! -f "$GH_CACHE" ]; then
+      resp=$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" 2>/dev/null)
+      if command -v jq >/dev/null 2>&1; then
+        tag=$(jq -r '.tag_name // empty' <<<"$resp")
+        url=$(jq -r '.assets[]?.browser_download_url // empty' <<<"$resp" | grep 'chatgpt-cli-secure' | head -n1)
+      else
+        echo "Aviso: jq não encontrado; a extração será menos robusta. Instale jq para melhor desempenho." >&2
+        tag=$(echo "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":\s*"v?([^\"]+)".*/\1/')
+        url=$(echo "$resp" | grep -o '"browser_download_url":[^,]*' | sed -E 's/.*"browser_download_url":\s*"([^\"]+)".*/\1/' | grep 'chatgpt-cli-secure' | head -n1)
+      fi
+      if [ -n "$tag" ] && [ -n "$url" ]; then
+        printf 'ETAG=%s\nTAG=%s\nURL=%s\n' "$token" "$tag" "$url" > "$GH_CACHE"
+      fi
     else
-      echo "Aviso: jq não encontrado; a extração será menos robusta. Instale jq para melhor desempenho." >&2
-      tag=$(echo "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name":\s*"v?([^\"]+)".*/\1/')
-      url=$(echo "$resp" | grep -o '"browser_download_url":[^,]*' | sed -E 's/.*"browser_download_url":\s*"([^\"]+)".*/\1/' | grep 'chatgpt-cli-secure' | head -n1)
+      tag=$(grep '^TAG=' "$GH_CACHE" | cut -d= -f2-)
+      url=$(grep '^URL=' "$GH_CACHE" | cut -d= -f2-)
     fi
     if [ -n "$tag" ] && [ -n "$url" ]; then
       latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
@@ -52,18 +76,36 @@ if [ -n "$GH_REPO" ]; then
     HUMAN_MSG="Erro ao consultar GitHub."
   fi
 elif [ -n "$UPDATE_URL" ]; then
-  tag=$(curl -fsSL "$UPDATE_URL/version.txt" 2>/dev/null | tr -d ' \t\n\r')
-  url="$UPDATE_URL/chatgpt-cli-secure.tar.gz"
-  if [ -n "$tag" ]; then
-    latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
-    if [ "$latest" != "$LOCAL_VERSION" ]; then
-      HAS_UPDATE=1
-      NEW_VERSION="$tag"
-      NEW_URL="$url"
+  # Padrão semelhante para URL direta usando `Last-Modified`.
+  headers=$(curl -fIsL "$UPDATE_URL/version.txt" 2>/dev/null)
+  if [ -n "$headers" ]; then
+    last_mod=$(grep -i '^Last-Modified:' <<<"$headers" | cut -d' ' -f2- | tr -d '\r')
+    token=$last_mod
+    cache_token=""
+    if [ -f "$URL_CACHE" ]; then
+      cache_token=$(grep '^ETAG=' "$URL_CACHE" | cut -d= -f2-)
+    fi
+    if [ "$token" != "$cache_token" ] || [ ! -f "$URL_CACHE" ]; then
+      tag=$(curl -fsSL "$UPDATE_URL/version.txt" 2>/dev/null | tr -d ' \t\n\r')
+      url="$UPDATE_URL/chatgpt-cli-secure.tar.gz"
+      if [ -n "$tag" ]; then
+        printf 'ETAG=%s\nTAG=%s\nURL=%s\n' "$token" "$tag" "$url" > "$URL_CACHE"
+      fi
+    else
+      tag=$(grep '^TAG=' "$URL_CACHE" | cut -d= -f2-)
+      url=$(grep '^URL=' "$URL_CACHE" | cut -d= -f2-)
+    fi
+    if [ -n "$tag" ]; then
+      latest=$(printf '%s\n%s\n' "$tag" "$LOCAL_VERSION" | sort -V | tail -n1)
+      if [ "$latest" != "$LOCAL_VERSION" ]; then
+        HAS_UPDATE=1
+        NEW_VERSION="$tag"
+        NEW_URL="$url"
+      fi
     fi
     HUMAN_MSG="Verificação via URL."
   else
-    HUMAN_MSG="Erro ao obter versão em URL."
+    HUMAN_MSG="Erro ao obter cabeçalhos em URL."
   fi
 else
   HUMAN_MSG="Nenhuma origem de atualização configurada."


### PR DESCRIPTION
## Summary
- Use `curl -fI` to fetch release headers and cache `ETag`/`Last-Modified` tokens
- Store cached metadata under `~/.local/state/chatgpt-cli` and reuse unless headers change
- Document header caching behaviour in README

## Testing
- `bash check-update.sh --machine-read`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9eec9700833089a7568fd8570792