### PR TITLE
refactor: apply strategy pattern for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@
   - `update.sh` baixa e instala a atualização a partir de GitHub, URL ou arquivo local.
   - A GUI integra o fluxo de verificação/instalação de atualização.
 
+```
+            UpdateStrategy
+           /      |      \
+GitHubStrategy URLStrategy FileStrategy
+```
+
+O `update.py` usa o **Strategy Pattern** para escolher a fonte de atualização em tempo de execução. Um dicionário de fábricas substitui longas cadeias de `if`/`elif`, permitindo inclusão de novas estratégias com custo constante de despacho.
+
 ## Dependências
 
 - **Obrigatórias**: `bash`, `python3` com biblioteca `requests`, `openssl`, `curl`, `zenity`.

--- a/tests/test_update_strategies.py
+++ b/tests/test_update_strategies.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from update_strategies import FileStrategy, UrlStrategy, GitHubStrategy, _safe_extract
+from update_strategies import FileStrategy, GitHubStrategy, URLStrategy, _safe_extract
 
 
 def _create_package(tmp_dir: Path, script: str) -> Path:
@@ -39,7 +39,7 @@ def test_file_strategy_executes_install(tmp_path: Path) -> None:
     out = tmp_path / "out.txt"
     os.environ["OUTPUT"] = str(out)
     try:
-        FileStrategy(tar_path).install()
+        FileStrategy(tar_path).run()
     finally:
         os.environ.pop("OUTPUT")
     assert out.read_text().strip() == "ok"
@@ -61,7 +61,7 @@ def test_url_strategy_downloads_and_installs(tmp_path: Path, monkeypatch: pytest
     out = tmp_path / "out.txt"
     os.environ["OUTPUT"] = str(out)
     try:
-        UrlStrategy(url).install()
+        URLStrategy(url).run()
     finally:
         os.environ.pop("OUTPUT")
     assert out.read_text().strip() == "ok"
@@ -91,7 +91,7 @@ def test_github_strategy_uses_check_script(tmp_path: Path, monkeypatch: pytest.M
     out = tmp_path / "out.txt"
     os.environ["OUTPUT"] = str(out)
     try:
-        GitHubStrategy().install()
+        GitHubStrategy().run()
     finally:
         os.environ.pop("OUTPUT")
     assert out.read_text().strip() == "ok"


### PR DESCRIPTION
## Summary
- define `UpdateStrategy` interface with `run()` method and implement `FileStrategy`, `URLStrategy` and `GitHubStrategy`
- refactor `update.py` to use mapping-based strategy selection
- describe strategy pattern usage in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcafc4130c833090815fc0c6b6f155