### PR TITLE
feat: add typed config loading

### DIFF
--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def load_module(monkeypatch: pytest.MonkeyPatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    dummy_requests = types.ModuleType("requests")
+    dummy_requests.Response = object
+    exc = types.ModuleType("requests.exceptions")
+    exc.RequestException = Exception
+    monkeypatch.setitem(sys.modules, "requests", dummy_requests)
+    monkeypatch.setitem(sys.modules, "requests.exceptions", exc)
+    return importlib.import_module("gpt_cli")
+
+
+def test_load_env_config_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    gpt_cli = load_module(monkeypatch)
+    monkeypatch.delenv('OPENAI_MODEL', raising=False)
+    monkeypatch.delenv('OPENAI_TEMP', raising=False)
+    cfg = gpt_cli.load_env_config({})
+    assert cfg.model == 'gpt-4o-mini'
+    assert cfg.temperature == 0.7
+
+
+def test_load_env_config_invalid_temp(monkeypatch: pytest.MonkeyPatch) -> None:
+    gpt_cli = load_module(monkeypatch)
+    monkeypatch.setenv('OPENAI_TEMP', '5')
+    with pytest.raises(ValueError):
+        gpt_cli.load_env_config({})

--- a/tests/test_stream_chat_completion.py
+++ b/tests/test_stream_chat_completion.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from gpt_cli import stream_chat_completion
+from gpt_cli import Config, stream_chat_completion
 
 
 class FakeResponse:
@@ -83,7 +83,9 @@ def test_stream_chat_completion_equivalence(monkeypatch) -> None:
 
     monkeypatch.setattr(requests, "post", fake_post_new)
     with redirect_stdout(StringIO()) as new_out:
-        new_result: str = stream_chat_completion("key", {}, 0.0)
+        new_result: str = stream_chat_completion(
+            "key", [], Config(model="m", temperature=0.0), 0.0
+        )
     new_print: str = new_out.getvalue()
 
     assert old_result == new_result


### PR DESCRIPTION
## Summary
- add `Config` dataclass and env loader with range validation
- refactor stream_chat_completion and main to use typed Config
- cover env loading with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcb19efafc8330b29c1dec81470a3a