### PR TITLE
Package CLI for distribution

### DIFF
--- a/chatgpt_cli/__init__.py
+++ b/chatgpt_cli/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/chatgpt_cli/__main__.py
+++ b/chatgpt_cli/__main__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Allow module execution via ``python -m chatgpt_cli``.
+
+The design follows the *Facade* pattern by exposing a simple entry point.
+Uma alternativa ligeiramente mais performática seria invocar diretamente
+``chatgpt_cli.main`` sem importação adicional, porém a diferença é mínima.
+"""
+
+from typing import NoReturn
+
+from . import main
+
+
+def run() -> NoReturn:
+    """Execute ``chatgpt_cli.main``.
+
+    Encapsular a chamada em função dedicada permite extensão futura sem
+    alterar o ponto de entrada. Um caminho mais rápido seria chamar ``main``
+    diretamente, evitando a chamada extra.
+    """
+    main()
+    raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    run()

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ if command -v rsync >/dev/null 2>&1; then
   rsync -a --delete --exclude '.git/' ./ "$PREFIX_DIR/"
 else
   mkdir -p "$PREFIX_DIR"
-  cp -f gpt_cli.py gpt-gui.sh gpt-secure-setup.sh update.sh check-update.sh version.txt README.md LICENSE "$PREFIX_DIR/"
+  cp -rf chatgpt_cli gpt-gui.sh gpt-secure-setup.sh update.sh check-update.sh version.txt README.md LICENSE "$PREFIX_DIR/"
   mkdir -p "$PREFIX_DIR/wrappers" "$PREFIX_DIR/desktop"
   cp -f wrappers/gpt wrappers/gpt-gui "$PREFIX_DIR/wrappers/"
   cp -f desktop/chatgpt-gui.desktop "$PREFIX_DIR/desktop/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chatgpt-cli-secure"
+version = "1.2.1"
+description = "Secure ChatGPT command line interface"
+authors = [{ name = "ChatGPT CLI" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "requests>=2.31.0",
+]
+
+[project.scripts]
+gpt = "chatgpt_cli:main"

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -14,20 +14,20 @@ def load_module(monkeypatch: pytest.MonkeyPatch):
     exc.RequestException = Exception
     monkeypatch.setitem(sys.modules, "requests", dummy_requests)
     monkeypatch.setitem(sys.modules, "requests.exceptions", exc)
-    return importlib.import_module("gpt_cli")
+    return importlib.import_module("chatgpt_cli")
 
 
 def test_load_env_config_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    gpt_cli = load_module(monkeypatch)
+    cli = load_module(monkeypatch)
     monkeypatch.delenv('OPENAI_MODEL', raising=False)
     monkeypatch.delenv('OPENAI_TEMP', raising=False)
-    cfg = gpt_cli.load_env_config({})
+    cfg = cli.load_env_config({})
     assert cfg.model == 'gpt-4o-mini'
     assert cfg.temperature == 0.7
 
 
 def test_load_env_config_invalid_temp(monkeypatch: pytest.MonkeyPatch) -> None:
-    gpt_cli = load_module(monkeypatch)
+    cli = load_module(monkeypatch)
     monkeypatch.setenv('OPENAI_TEMP', '5')
     with pytest.raises(ValueError):
-        gpt_cli.load_env_config({})
+        cli.load_env_config({})

--- a/tests/test_executable_permissions.py
+++ b/tests/test_executable_permissions.py
@@ -9,12 +9,11 @@ from .util import assert_exec
 
 # Explicit enumeration avoids false positives and acts as a simple whitelist.
 # ``Path.rglob('*.sh')`` could discover scripts dynamically and be more
-# performant in large trees, but manual listing keeps intent clear.
+# performant in large trees, mas a listagem manual mantém a intenção clara.
 EXECUTABLES: List[Path] = [
     Path("check-update.sh"),
     Path("gpt-gui.sh"),
     Path("gpt-secure-setup.sh"),
-    Path("gpt_cli.py"),
     Path("install.sh"),
     Path("uninstall.sh"),
     Path("update.sh"),

--- a/tests/test_read_config.py
+++ b/tests/test_read_config.py
@@ -12,8 +12,8 @@ def test_read_config_invalid_file(tmp_path: Path, monkeypatch) -> None:
     exc.RequestException = Exception
     monkeypatch.setitem(sys.modules, "requests", dummy_requests)
     monkeypatch.setitem(sys.modules, "requests.exceptions", exc)
-    gpt_cli = importlib.import_module("gpt_cli")
+    cli = importlib.import_module("chatgpt_cli")
     config_file: Path = tmp_path / "config"
     config_file.write_text("invalid-line")
-    monkeypatch.setattr(gpt_cli, "CONFIG_PATH", config_file)
-    assert gpt_cli.read_config() == {}
+    monkeypatch.setattr(cli, "CONFIG_PATH", config_file)
+    assert cli.read_config() == {}

--- a/tests/test_stream_chat_completion.py
+++ b/tests/test_stream_chat_completion.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from gpt_cli import Config, stream_chat_completion
+from chatgpt_cli import Config, stream_chat_completion
 
 
 class FakeResponse:
@@ -29,7 +29,7 @@ class FakeResponse:
 
 
 def old_stream_chat_completion(
-    api_key: str, payload: Dict[str, Any], timeout: float
+    api_key: str, payload: Dict[str, Any], timeout: float,
 ) -> str:
     headers: Dict[str, str] = {
         "Authorization": "Bearer " + api_key,
@@ -84,7 +84,7 @@ def test_stream_chat_completion_equivalence(monkeypatch) -> None:
     monkeypatch.setattr(requests, "post", fake_post_new)
     with redirect_stdout(StringIO()) as new_out:
         new_result: str = stream_chat_completion(
-            "key", [], Config(model="m", temperature=0.0), 0.0
+            "key", [], Config(model="m", temperature=0.0), 0.0,
         )
     new_print: str = new_out.getvalue()
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,15 +6,19 @@ import subprocess
 from pathlib import Path
 
 
-def test_gpt_wrapper_resolves_moved_script(tmp_path: Path) -> None:
+def test_gpt_wrapper_resolves_moved_package(tmp_path: Path) -> None:
     wrapper_src: Path = Path("wrappers/gpt")
     wrapper_dest_dir: Path = tmp_path / "wrappers"
     wrapper_dest_dir.mkdir()
     wrapper_dest: Path = wrapper_dest_dir / "gpt"
     shutil.copy(wrapper_src, wrapper_dest)
 
-    dummy_script: Path = tmp_path / "gpt_cli.py"
-    dummy_script.write_text("print('gpt_cli_ok')\n")
+    pkg_dir: Path = tmp_path / "chatgpt_cli"
+    pkg_dir.mkdir()
+    init: Path = pkg_dir / "__init__.py"
+    init.write_text("def main() -> None:\n    print('gpt_cli_ok')\n")
+    main_file: Path = pkg_dir / "__main__.py"
+    main_file.write_text("from . import main\nmain()\n")
 
     wrapper_dest.chmod(wrapper_dest.stat().st_mode | stat.S_IEXEC)
 

--- a/wrappers/gpt
+++ b/wrappers/gpt
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
-"""Wrapper to execute gpt_cli.py using the current Python interpreter."""
+"""Wrapper to execute ``chatgpt_cli`` as a module using the current Python interpreter."""
 
 from __future__ import annotations
 
 import os
 import sys
 from pathlib import Path
-from typing import NoReturn
+from typing import Dict, NoReturn
+
 
 def main() -> NoReturn:
-    """Run the CLI script relative to this wrapper.
+    """Run the package entry point relative to this wrapper.
 
-    Uses ``os.execv`` to replace the current process with ``gpt_cli.py``,
-    avoiding the overhead of spawning a child process. An alternative is
-    ``subprocess.run`` which offers more control but is slightly slower due
-    to process creation.
+    Emprega ``os.execvpe`` para substituir o processo atual por
+    ``python -m chatgpt_cli``, eliminando overhead de criação de filho. Uma
+    alternativa, um pouco mais lenta porém mais controlável, seria
+    ``subprocess.run``.
     """
     script_dir: Path = Path(__file__).resolve().parent
-    gpt_cli: Path = script_dir.parent / "gpt_cli.py"
-    os.execv(sys.executable, [sys.executable, str(gpt_cli), *sys.argv[1:]])
+    repo_root: Path = script_dir.parent
+    os.chdir(repo_root)
+    env: Dict[str, str] = os.environ.copy()
+    pythonpath: str = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{pythonpath}" if pythonpath else str(repo_root)
+    os.execvpe(sys.executable, [sys.executable, "-m", "chatgpt_cli", *sys.argv[1:]], env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- package CLI into `chatgpt_cli` module with entry points
- add pyproject metadata exposing `gpt` script via `[project.scripts]`
- adjust wrappers, install script and tests for module import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0b4983483308ae86c6f7800002d