### PR TITLE
docs: add API key setup callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ O diretório `~/.local/bin` precisa estar no `PATH` para que `gpt` e `gpt-gui` f
 
 > **Nota:** Após a instalação, talvez seja necessário reindexar o menu de aplicativos (ou reiniciar o ambiente gráfico) para que o atalho apareça.
 
+> **Pré-requisito:** antes de usar `gpt` ou `gpt-gui`, execute `bash "$PREFIX_DIR/gpt-secure-setup.sh"` para armazenar a chave API de forma criptografada.  
+> **Alternativa menos segura:** exporte `OPENAI_API_KEY` manualmente (`export OPENAI_API_KEY="sua_chave"`); ⚠️ a chave ficará exposta em texto claro no ambiente.
+
 ## Uso da CLI
 
 ### Envio básico


### PR DESCRIPTION
## Summary
- highlight gpt-secure-setup.sh as a prerequisite for `gpt`/`gpt-gui`
- mention manual OPENAI_API_KEY export as a less secure alternative

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4f330f88330ba63f99852b746d8