### PR TITLE
Detecta HOME correta ao executar via sudo

### DIFF
--- a/gpt-secure-setup.sh
+++ b/gpt-secure-setup.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # Script para configurar chave da API OpenAI de forma segura.
 set -e
-SECRET_DIR="$HOME/.local/share/chatgpt-cli"
-CONFIG_DIR="$HOME/.config/chatgpt-cli"
+
+# Resolve HOME para o usuário correto (suporta sudo)
+REAL_USER="${SUDO_USER:-$(id -un)}"
+USER_HOME="$(getent passwd "$REAL_USER" | cut -d: -f6)"
+
+SECRET_DIR="$USER_HOME/.local/share/chatgpt-cli"
+CONFIG_DIR="$USER_HOME/.config/chatgpt-cli"
 mkdir -p "$SECRET_DIR"
 mkdir -p "$CONFIG_DIR"
 


### PR DESCRIPTION
## Summary
- Resolve HOME real quando executado via sudo no `gpt-secure-setup.sh`
- Usa diretórios de configuração com base na HOME detectada

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd933971c8330a81ce12020dc8b67