### PR TITLE
refactor: use builtin list for dependencies

### DIFF
--- a/utils/dependency_manager.py
+++ b/utils/dependency_manager.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable
 import tomllib
 
 PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
-def _read_dependencies(pyproject_path: Path = PYPROJECT) -> List[str]:
+
+def _read_dependencies(pyproject_path: Path = PYPROJECT) -> list[str]:
     """Read project dependencies from pyproject.toml."""
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)


### PR DESCRIPTION
## Summary
- refactor dependency manager to return built-in `list[str]`

## Testing
- `mypy utils/dependency_manager.py`
- `mypy .` *(fails: Module has no attribute "Response"; missing cryptography and requests stubs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68bce21a430883309b3cce1325d32c98