### PR TITLE
feat: add descriptive decrypt error

### DIFF
--- a/tests/test_secure_storage.py
+++ b/tests/test_secure_storage.py
@@ -2,7 +2,6 @@ import stat
 from pathlib import Path
 
 import pytest
-from cryptography.exceptions import InvalidTag
 
 from chatgpt_cli.secure_storage import (
     AesGcmCipher,
@@ -22,12 +21,12 @@ def test_save_and_load_api_key(tmp_path: Path) -> None:
 
 
 def test_load_api_key_errors(tmp_path: Path) -> None:
-    """Ensure wrong password or corrupted file raises an exception."""
+    """Ensure wrong password or corrupted file raises a descriptive error."""
     loc = KeyLocation(base_dir=tmp_path)
     save_api_key("chave-teste", "senha-correta", loc=loc, cipher=AesGcmCipher())
 
     # Wrong password should not decrypt
-    with pytest.raises((ValueError, InvalidTag)):
+    with pytest.raises(ValueError, match="senha incorreta ou dados corrompidos"):
         load_api_key("senha-errada", loc=loc, cipher=AesGcmCipher())
 
     # Corrupt stored data and expect failure
@@ -35,5 +34,5 @@ def test_load_api_key_errors(tmp_path: Path) -> None:
     data[0] ^= 0xFF
     loc.path.write_bytes(data)
 
-    with pytest.raises((ValueError, InvalidTag)):
+    with pytest.raises(ValueError, match="senha incorreta ou dados corrompidos"):
         load_api_key("senha-correta", loc=loc, cipher=AesGcmCipher())


### PR DESCRIPTION
## Summary
- raise clear error when API key decryption fails
- test decryption failure raises descriptive message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bce3a4957c8330956c4241d24993d0