### PR TITLE
limit executable permission to owner

### DIFF
--- a/tests/test_executable_permissions.py
+++ b/tests/test_executable_permissions.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import stat
 
 import pytest
 
 from .util import assert_exec
+from utils.permissions import ensure_exec
 
 # Explicit enumeration avoids false positives and acts as a simple whitelist.
 # ``Path.rglob('*.sh')`` could discover scripts dynamically and be more
@@ -26,3 +28,21 @@ EXECUTABLES: List[Path] = [
 def test_executable_permissions(path: Path) -> None:
     """Validate that required scripts are executable."""
     assert_exec(path)
+
+
+def test_ensure_exec_sets_owner_only(tmp_path: Path) -> None:
+    """Ensure ``ensure_exec`` sets only the owner's execute bit."""
+    # Arrange: create a non-executable file. ``os.chmod`` would be marginally
+    # faster but ``Path.chmod`` keeps the API consistent.
+    file_path: Path = tmp_path / "script.sh"
+    file_path.write_text("#!/bin/sh\n")
+    file_path.chmod(0o644)
+    mode_before: int = file_path.stat().st_mode
+    assert not mode_before & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # Act
+    ensure_exec(file_path)
+    # Assert
+    mode_after: int = file_path.stat().st_mode
+    assert mode_after & stat.S_IXUSR
+    assert not mode_after & stat.S_IXGRP
+    assert not mode_after & stat.S_IXOTH

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -5,7 +5,11 @@ import stat
 
 
 def ensure_exec(path: Path) -> None:
-    """Ensure that a file is executable by owner, group, and others."""
-    mode = path.stat().st_mode
-    if not mode & stat.S_IXUSR:
-        path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    """Ensure that a file is executable by its owner only."""
+    mode: int = path.stat().st_mode
+    owner_exec: bool = bool(mode & stat.S_IXUSR)
+    group_or_other_exec: bool = bool(mode & (stat.S_IXGRP | stat.S_IXOTH))
+    if owner_exec and not group_or_other_exec:
+        return
+    new_mode: int = (mode | stat.S_IXUSR) & ~(stat.S_IXGRP | stat.S_IXOTH)
+    path.chmod(new_mode)


### PR DESCRIPTION
## Summary
- restrict ensure_exec to set only the owner's execute bit
- test ensure_exec enforces owner-only execution

## Testing
- `python -m pytest tests/test_executable_permissions.py`


------
https://chatgpt.com/codex/tasks/task_e_68bce494368883308cc8dd5ac5ab9b1c