### PR TITLE
Store API key in plaintext

### DIFF
--- a/gpt_secure_setup.py
+++ b/gpt_secure_setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Configura a chave API de forma segura usando ``save_api_key``."""
+"""Configura a chave API de forma simples usando ``save_api_key``."""
 
 from getpass import getpass
 
@@ -7,21 +7,13 @@ from chatgpt_cli.secure_storage import KeyLocation, save_api_key
 
 
 def main() -> None:
-    print("Configuração segura da chave API OpenAI.")
+    print("Configuração da chave API OpenAI.")
     api_key: str = getpass("Digite sua OpenAI API key: ")
     if not api_key:
         print("Chave vazia. Abortando.")
         return
-    pass1: str = getpass("Crie uma senha mestra: ")
-    pass2: str = getpass("Confirme a senha mestra: ")
-    if not pass1:
-        print("Senha vazia. Abortando.")
-        return
-    if pass1 != pass2:
-        print("As senhas não coincidem.")
-        return
-    save_api_key(api_key, pass1)
-    print(f"Chave criptografada e salva em {KeyLocation().path}")
+    save_api_key(api_key)
+    print(f"Chave salva em {KeyLocation().path}")
 
 
 if __name__ == "__main__":

--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,7 @@ def finalize(commands: List[str], bin_dir: Path, secret: Path) -> None:
 bin_dir = Path(os.environ.get('BIN_DIR', str(Path.home() / '.local/bin')))
 secret_path = (
     Path(os.environ.get('PREFIX_DIR', str(Path.home() / '.local/share/chatgpt-cli')))
-    / 'secret.enc'
+    / 'secret.txt'
 )
 finalize(['gpt', 'gpt-gui'], bin_dir, secret_path)
 PY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "requests>=2.31.0",
-    "cryptography>=42.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_get_api_key_cache.py
+++ b/tests/test_get_api_key_cache.py
@@ -9,12 +9,12 @@ from chatgpt_cli import get_api_key
 def test_get_api_key_calls_decrypt_once(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: int = 0
 
-    def fake_load_api_key(password: str, loc: object) -> str:
+    def fake_load_api_key(*, loc: object) -> str:
         nonlocal calls
         calls += 1
         return "decrypted"
 
-    secret_file: Path = tmp_path / "secret.enc"
+    secret_file: Path = tmp_path / "secret.txt"
     secret_file.write_text("data")
 
     class DummyLocation:
@@ -23,7 +23,6 @@ def test_get_api_key_calls_decrypt_once(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     monkeypatch.setattr(chatgpt_cli, "load_api_key", fake_load_api_key)
     monkeypatch.setattr(chatgpt_cli, "KeyLocation", DummyLocation)
-    monkeypatch.setenv("OPENAI_MASTER_PASSWORD", "pwd")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     get_api_key.cache_clear()
 

--- a/tests/test_secure_storage.py
+++ b/tests/test_secure_storage.py
@@ -3,36 +3,19 @@ from pathlib import Path
 
 import pytest
 
-from chatgpt_cli.secure_storage import (
-    AesGcmCipher,
-    KeyLocation,
-    load_api_key,
-    save_api_key,
-)
+from chatgpt_cli.secure_storage import KeyLocation, load_api_key, save_api_key
 
 
 def test_save_and_load_api_key(tmp_path: Path) -> None:
     loc = KeyLocation(base_dir=tmp_path)
-    save_api_key("chave-teste", "senha", loc=loc, cipher=AesGcmCipher())
-    recovered = load_api_key("senha", loc=loc, cipher=AesGcmCipher())
+    save_api_key("chave-teste", loc=loc)
+    recovered = load_api_key(loc=loc)
     assert recovered == "chave-teste"
     mode = stat.S_IMODE(loc.path.stat().st_mode)
     assert mode == 0o600
 
 
-def test_load_api_key_errors(tmp_path: Path) -> None:
-    """Ensure wrong password or corrupted file raises a descriptive error."""
+def test_load_api_key_missing_file(tmp_path: Path) -> None:
     loc = KeyLocation(base_dir=tmp_path)
-    save_api_key("chave-teste", "senha-correta", loc=loc, cipher=AesGcmCipher())
-
-    # Wrong password should not decrypt
-    with pytest.raises(ValueError, match="senha incorreta ou dados corrompidos"):
-        load_api_key("senha-errada", loc=loc, cipher=AesGcmCipher())
-
-    # Corrupt stored data and expect failure
-    data = bytearray(loc.path.read_bytes())
-    data[0] ^= 0xFF
-    loc.path.write_bytes(data)
-
-    with pytest.raises(ValueError, match="senha incorreta ou dados corrompidos"):
-        load_api_key("senha-correta", loc=loc, cipher=AesGcmCipher())
+    with pytest.raises(FileNotFoundError):
+        load_api_key(loc=loc)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -38,7 +38,7 @@ if [ "$PURGE" = true ]; then
   rm -rf "$PREFIX_DIR"
   rm -rf "$STATE_DIR"
   rm -rf "$SHARE_DIR" "$CONFIG_DIR"
-  rm -f "$SHARE_DIR/secret.enc"
+  rm -f "$SHARE_DIR/secret.txt"
   rm -f "$CONFIG_DIR/config"
   echo "Todos os dados e scripts foram removidos."
 fi


### PR DESCRIPTION
## Summary
- simplify secure_storage to save API key as plain text
- drop password prompts and cryptography dependency throughout CLI and GUI
- adjust docs, scripts, and tests for new plaintext storage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bce78cc3188330ad01931c51772c6b