### PR TITLE
feat: allow configurable repo root

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -25,6 +25,7 @@ def test_gpt_wrapper_resolves_moved_package(tmp_path: Path) -> None:
 
     env: dict[str, str] = os.environ.copy()
     env["OPENAI_API_KEY"] = "test"
+    env["PREFIX_DIR"] = str(tmp_path)
     result: subprocess.CompletedProcess[str] = subprocess.run(
         [str(wrapper_dest)], capture_output=True, text=True, check=True, env=env
     )

--- a/wrappers/gpt
+++ b/wrappers/gpt
@@ -18,8 +18,9 @@ def main() -> NoReturn:
     ``python -m chatgpt_cli``, evitando inicializar o Python apenas para
     redirecionar o processo.
     """
-    script_dir: Path = Path(__file__).resolve().parent
-    repo_root: Path = script_dir.parent
+    repo_root_env: str | None = os.environ.get("PREFIX_DIR")
+    default_repo: Path = Path.home() / ".local" / "share" / "chatgpt-cli"
+    repo_root: Path = Path(repo_root_env) if repo_root_env else default_repo
     os.chdir(repo_root)
     sys.path.insert(0, str(repo_root))
     env: Dict[str, str] = os.environ.copy()


### PR DESCRIPTION
## Summary
- allow wrappers/gpt to resolve repo root via PREFIX_DIR env var or default share directory
- set PREFIX_DIR during wrapper relocation tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa0fad5883308a4c04276af7f6ca